### PR TITLE
set fn on only when k380 is detected

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ BUILD_PATH=$(dirname "$BUILD_SH")
 FN_ON="$BUILD_PATH/fn_on.sh"
 UDEV_RULES="$BUILD_PATH/80-k380.rules"
 
-echo "ACTION==\"add\", KERNEL==\"hidraw[0-9]\", RUN+=\"$FN_ON\"" > $UDEV_RULES
+echo "ACTION==\"add\", KERNEL==\"hidraw[0-9]*\", RUN+=\"$FN_ON /dev/%k\"" > $UDEV_RULES
 echo "To automatically turn on fn using udev rules, run the following command"
 echo "    sudo cp $UDEV_RULES /etc/udev/rules.d/ && sudo udevadm control -R"
 

--- a/fn_on.sh
+++ b/fn_on.sh
@@ -5,7 +5,7 @@ TOOL="$(dirname $0)/k380_conf"
 DEV="$(ls /sys/class/hidraw/ -l | grep 046D:B342 | grep -o 'hidraw[0-9]*$')"
 
 
-if test -n "$DEV" 
+if test -n "$DEV" && (test -z "$1" || test "/dev/$DEV" = "$1")
 then
     echo "Found K380 at $DEV"
     $TOOL -d "/dev/$DEV" -f on


### PR DESCRIPTION
set fn on only when k380 is detected, not every time a HID device is detected.